### PR TITLE
fix: handle missing self.wolfie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,162 @@
 *.pyc
 settings.json
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/__init__.py
+++ b/__init__.py
@@ -80,9 +80,6 @@ class WolframAlphaSkill(CommonQuerySkill):
     @intent_handler("search_wolfie.intent")
     def handle_search(self, message: Message):
         query = message.data["query"]
-        if self.wolfie is not None:
-            # Give ourselves a little time to get a response in
-            self.bus.emit(message.reply(msg_type=message.msg_type, data={"searching": True}, context=message.context))
         response = self.ask_the_wolf(query)
         if response:
             self.speak_result()
@@ -96,16 +93,17 @@ class WolframAlphaSkill(CommonQuerySkill):
         self.speak_result()
 
     # common query integration
-    def CQS_match_query_phrase(self, utt):
-        self.log.debug("WolframAlpha query: " + utt)
+    def CQS_match_query_phrase(self, phrase):
+        self.log.debug("WolframAlpha query: " + phrase)
         if self.wolfie is None:
             self.log.error("WolframAlphaSkill not initialized, no response")
             return
-        response = self.ask_the_wolf(utt)
+        response = self.ask_the_wolf(phrase)
         if response:
             self.idx += 1  # spoken by common query framework
-            return (utt, CQSMatchLevel.GENERAL, response,
-                    {'query': utt, 'answer': response})
+            self.log.debug("WolframAlpha response: %s", response)
+            return (phrase, CQSMatchLevel.GENERAL, response,
+                    {'query': phrase, 'answer': response})
 
     def CQS_action(self, phrase, data):
         """ If selected show gui """

--- a/__init__.py
+++ b/__init__.py
@@ -120,6 +120,7 @@ class WolframAlphaSkill(CommonQuerySkill):
         self.results = [s for s in results if s.get("title") not in self.skips]
         if len(self.results):
             return self.results[0]["summary"]
+        self.log.debug("WolframAlpha had no answers for %s", query)
 
     def display_wolfie(self):
         if not can_use_gui(self.bus):

--- a/__init__.py
+++ b/__init__.py
@@ -13,6 +13,7 @@
 from os.path import join
 
 from neon_solver_wolfram_alpha_plugin import WolframAlphaSolver
+from ovos_bus_client import Message
 from ovos_utils import classproperty
 from ovos_utils.gui import can_use_gui
 from ovos_utils.intents import IntentBuilder
@@ -77,8 +78,11 @@ class WolframAlphaSkill(CommonQuerySkill):
 
     # explicit intents
     @intent_handler("search_wolfie.intent")
-    def handle_search(self, message):
+    def handle_search(self, message: Message):
         query = message.data["query"]
+        if self.wolfie is not None:
+            # Give ourselves a little time to get a response in
+            self.bus.emit(message.reply(msg_type=message.msg_type, data={"searching": True}, context=message.context))
         response = self.ask_the_wolf(query)
         if response:
             self.speak_result()

--- a/__init__.py
+++ b/__init__.py
@@ -53,6 +53,13 @@ class WolframAlphaSkill(CommonQuerySkill):
             'Scrabble score',  # spammy
             'Other notable uses'  # spammy
         ]
+        try:
+            self.wolfie = WolframAlphaSolver({
+                "units": self.config_core['system_unit'],
+                "appid": self.settings.get("api_key")
+            })
+        except Exception as err:
+            self.log.error("WolframAlphaSkill failed to initialize: %s", err)
 
     @classproperty
     def runtime_requirements(self):
@@ -66,15 +73,6 @@ class WolframAlphaSkill(CommonQuerySkill):
                                    no_network_fallback=False,
                                    no_gui_fallback=True)
 
-    def initialize(self):
-        try:
-            self.wolfie = WolframAlphaSolver({
-                "units": self.config_core['system_unit'],
-                "appid": self.settings.get("api_key")
-            })
-        except Exception as err:
-            self.log.error("WolframAlphaSkill failed to initialize: %s", err)
-
     # explicit intents
     @intent_handler("search_wolfie.intent")
     def handle_search(self, message: Message):
@@ -87,7 +85,7 @@ class WolframAlphaSkill(CommonQuerySkill):
 
     @intent_handler(IntentBuilder("WolfieMore").require("More").
                     require("WolfieKnows"))
-    def handle_tell_more(self, message):
+    def handle_tell_more(self, _):
         """ Follow up query handler, "tell me more"."""
         self.speak_result()
 
@@ -159,7 +157,3 @@ class WolframAlphaSkill(CommonQuerySkill):
                 ans = ans.replace(" | ", "; ")
                 self.speak(ans)
             self.idx += 1
-
-
-def create_skill():
-    return WolframAlphaSkill()

--- a/__init__.py
+++ b/__init__.py
@@ -53,6 +53,13 @@ class WolframAlphaSkill(CommonQuerySkill):
             'Scrabble score',  # spammy
             'Other notable uses'  # spammy
         ]
+        try:
+            self.wolfie = WolframAlphaSolver({
+                "units": self.config_core['system_unit'],
+                "appid": self.settings.get("api_key")
+            })
+        except Exception as err:
+            self.log.error("WolframAlphaSkill failed to initialize: %s", err)
 
     @classproperty
     def runtime_requirements(self):
@@ -65,15 +72,6 @@ class WolframAlphaSkill(CommonQuerySkill):
                                    no_internet_fallback=False,
                                    no_network_fallback=False,
                                    no_gui_fallback=True)
-
-    def initialize(self):
-        try:
-            self.wolfie = WolframAlphaSolver({
-                "units": self.config_core['system_unit'],
-                "appid": self.settings.get("api_key")
-            })
-        except Exception as err:
-            self.log.error("WolframAlphaSkill failed to initialize: %s", err)
 
     # explicit intents
     @intent_handler("search_wolfie.intent")

--- a/__init__.py
+++ b/__init__.py
@@ -53,13 +53,6 @@ class WolframAlphaSkill(CommonQuerySkill):
             'Scrabble score',  # spammy
             'Other notable uses'  # spammy
         ]
-        try:
-            self.wolfie = WolframAlphaSolver({
-                "units": self.config_core['system_unit'],
-                "appid": self.settings.get("api_key")
-            })
-        except Exception as err:
-            self.log.error("WolframAlphaSkill failed to initialize: %s", err)
 
     @classproperty
     def runtime_requirements(self):
@@ -72,6 +65,15 @@ class WolframAlphaSkill(CommonQuerySkill):
                                    no_internet_fallback=False,
                                    no_network_fallback=False,
                                    no_gui_fallback=True)
+
+    def initialize(self):
+        try:
+            self.wolfie = WolframAlphaSolver({
+                "units": self.config_core['system_unit'],
+                "appid": self.settings.get("api_key")
+            })
+        except Exception as err:
+            self.log.error("WolframAlphaSkill failed to initialize: %s", err)
 
     # explicit intents
     @intent_handler("search_wolfie.intent")
@@ -157,3 +159,7 @@ class WolframAlphaSkill(CommonQuerySkill):
                 ans = ans.replace(" | ", "; ")
                 self.speak(ans)
             self.idx += 1
+
+
+def create_skill():
+    return WolframAlphaSkill()

--- a/__init__.py
+++ b/__init__.py
@@ -53,7 +53,6 @@ class WolframAlphaSkill(CommonQuerySkill):
             'Scrabble score',  # spammy
             'Other notable uses'  # spammy
         ]
-        self.initialize()
 
     @classproperty
     def runtime_requirements(self):
@@ -160,7 +159,3 @@ class WolframAlphaSkill(CommonQuerySkill):
                 ans = ans.replace(" | ", "; ")
                 self.speak(ans)
             self.idx += 1
-
-
-def create_skill():
-    return WolframAlphaSkill()

--- a/test/unittests/test_common_query.py
+++ b/test/unittests/test_common_query.py
@@ -2,7 +2,7 @@ import json
 import unittest
 from unittest.mock import Mock
 from time import sleep
-from mycroft.skills import FallbackSkill
+from ovos_workshop.skills.fallback import FallbackSkill
 from ovos_skill_common_query import QuestionsAnswersSkill
 from ovos_utils.messagebus import FakeBus, Message
 from skill_ovos_wolfie import WolframAlphaSkill
@@ -152,6 +152,8 @@ class TestCommonQuery(unittest.TestCase):
             m = self.bus.emitted_msgs[ctr]
             if m["data"].get("conf"):
                 m["data"]["conf"] = 0.0
+            print(msg)
+            print(m)
             self.assertEqual(msg, m)
 
     @unittest.skip("TODO debug and fix me")

--- a/test/unittests/test_skill.py
+++ b/test/unittests/test_skill.py
@@ -3,7 +3,7 @@ import unittest
 
 from ovos_utils.messagebus import FakeBus
 from skill_ovos_wolfie import WolframAlphaSkill
-from mycroft.skills import CommonQuerySkill
+from ovos_workshop.skills.common_query_skill import CommonQuerySkill
 
 
 class TestSkill(unittest.TestCase):


### PR DESCRIPTION
Fixes #13 

- Move to modern OVOS `self.__init__()` instead of classic Mycroft `self.initialize()` with `create_skill()` function
- Add logging
- Don't override base class parameter names
- Add error handling where `self.wolfie` may not be instantiated
- Remove references to Mycroft imports in favor of OVOS imports

Works on the Mark 1 Raspbian OVOS image!

```python
ovos@mark1-dev:~ $ cat ~/.local/state/mycroft/skills.log | grep wolfie
2023-08-18 22:42:22.331 - skill-ovos-wolfie.openvoiceos - DEBUG - WolframAlpha query: what are the first 14 digits of pi
2023-08-18 22:42:23.335 - skill-ovos-wolfie.openvoiceos - DEBUG - [{'title': 'Nearby digits', 'summary': 'Nearby digits.\n3.1415926535897932384626433832795028841971693993751...'}, {'title': 'Digit counts', 'img': 'https://www6b3.wolframalpha.com/Calculate/MSP/MSP504023ha69396debcd4600003hbh1i4428d2af25?MSPStoreType=image/gif&s=14'}]
2023-08-18 22:42:23.335 - skill-ovos-wolfie.openvoiceos - DEBUG - WolframAlpha response: Nearby digits.
2023-08-18 22:42:23.353 - skills - ovos_core.intent_services.commonqa_service:handle_query_response:156 - INFO - Answer from skill-ovos-wolfie.openvoiceos
2023-08-18 22:42:23.359 - skills - ovos_core.intent_services.commonqa_service:_query_timeout:202 - INFO - Handling with: skill-ovos-wolfie.openvoiceos
```